### PR TITLE
collector/Logout: fix a crash when the switch is unavailable

### DIFF
--- a/internal/collector.go
+++ b/internal/collector.go
@@ -253,10 +253,11 @@ func (c *Collector) Logout() {
 	resp, err := client.Get("http://" + c.address + "/logout.html")
 	if err != nil {
 		fmt.Println("Warning:", err)
+		return
 	}
+	defer resp.Body.Close()
 	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		fmt.Println("Warning:", err)
 	}
-	defer resp.Body.Close()
 }


### PR DESCRIPTION
If client.Get fails, we do not want to do anything as resp is nil. Otherwise we want to defer closing the response body before io.Copy in case it panics.