### PR TITLE
feat: add port duplex status ans speed unit as tags

### DIFF
--- a/internal/collector.go
+++ b/internal/collector.go
@@ -44,6 +44,8 @@ type PortData struct {
 	loop_status string
 	portstatus  string
 	speed       int
+	speedUnit   string
+	duplex      string
 	stats       PortStats
 	pvlan       string
 	vlans       []string
@@ -168,7 +170,15 @@ func (c *Collector) Collect() (*SystemData, *[]PortData, error) {
 		}
 
 		// Port speed seems to always be "[num] Mbps".
-		portData[i].speed, _ = strconv.Atoi(strings.ReplaceAll(speed[i], " Mbps", ""))
+		log.Printf("%v", speed[i])
+		speedInfo := strings.Fields(speed[i])
+		portData[i].speed, _ = strconv.Atoi(speedInfo[0])
+		portData[i].speedUnit = speedInfo[1]
+		if len(speedInfo) > 2 {
+			portData[i].duplex = speedInfo[2]
+		} else {
+			portData[i].duplex = ""
+		}
 
 		// Sent/received traffic has a weird structure. This is what Zyxel's
 		// code does:

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -25,8 +25,8 @@ var (
 		[]string{"vlans"}, nil)
 	speed_metric = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "speed"),
-		"Port speed in Mbps.",
-		[]string{"port", "status", "loop", "pvlan", "vlans"}, nil)
+		"Port speed.",
+		[]string{"port", "status", "loop", "pvlan", "vlans", "unit", "duplex"}, nil)
 	tx_metric = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "packets_tx"),
 		"Number of packets transmitted.",
@@ -81,7 +81,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for _, port := range *portData {
 		ch <- prometheus.MustNewConstMetric(speed_metric, prometheus.GaugeValue,
 			float64(port.speed), port.name, port.portstatus, port.loop_status,
-			port.pvlan, strings.Join(port.vlans, ","))
+			port.pvlan, strings.Join(port.vlans, ","), port.speedUnit, port.duplex)
 		ch <- prometheus.MustNewConstMetric(rx_metric, prometheus.GaugeValue,
 			port.stats.rx, port.name)
 		ch <- prometheus.MustNewConstMetric(tx_metric, prometheus.GaugeValue,


### PR DESCRIPTION
Recent firmwares apparently display speed as something like '1000 Mbps Full', where previously it was '1000 Mbps', causing the string parser to not properly extract the speed.

We now split the port speed string on whitespace, making sure we have the integer value, and use the other 1 or two parts as tags.